### PR TITLE
Overrides Jenkins default BUILD_ID and BUILD_NUMBER when running as a…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jx/resources/ProwEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/resources/ProwEnvironmentContributor.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.jx.resources;
+
+import javax.annotation.Nonnull;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+/**
+ * Injects environment variables provided by Prow which are normally set by Jenkins core.
+ */
+@Extension
+public class ProwEnvironmentContributor extends EnvironmentContributor {
+    @Override
+    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
+        if (System.getenv("PROW_JOB_ID") != null) {
+            envs.put("BUILD_ID", System.getenv("BUILD_ID"));
+            envs.put("BUILD_NUMBER", System.getenv("BUILD_NUMBER"));
+        }
+    }
+}


### PR DESCRIPTION
… prow job

cc @garethjevans 

I think this will fix https://github.com/jenkins-x/jx/issues/2431 / https://github.com/jenkins-x/jx/issues/2482