### PR TITLE
Prow environment variables handling improvement

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jx/resources/ProwEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/resources/ProwEnvironmentContributor.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.jx.resources;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.EnvironmentContributor;
@@ -15,9 +17,21 @@ import hudson.model.TaskListener;
 public class ProwEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
-        if (System.getenv("PROW_JOB_ID") != null) {
-            envs.put("BUILD_ID", System.getenv("BUILD_ID"));
-            envs.put("BUILD_NUMBER", System.getenv("BUILD_NUMBER"));
+        String prowJobId = getEnv("PROW_JOB_ID");
+        if (prowJobId != null) {
+            String buildId = getEnv("BUILD_ID");
+            if (buildId != null) {
+                // Overrides Jenkins predefined environment variables with the one provided by Prow
+                envs.put("BUILD_ID", buildId);
+                envs.put("BUILD_NUMBER", buildId);
+            } else {
+                listener.getLogger().printf("[WARN] In a Prow job (PROW_JOB_ID = %s), expected BUILD_ID to be non-null", prowJobId);
+            }
         }
+    }
+
+    @VisibleForTesting
+    String getEnv(String name) {
+        return System.getenv(name);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/jx/resources/ProwEnvironmentContributorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jx/resources/ProwEnvironmentContributorTest.java
@@ -1,0 +1,76 @@
+package org.jenkinsci.plugins.jx.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProwEnvironmentContributorTest {
+
+    @Mock
+    Run run;
+
+    @Mock
+    TaskListener listener;
+
+    @Before
+    public void setUp() {
+        when(listener.getLogger()).thenReturn(System.out);
+    }
+
+    @Test
+    public void whenProwJobIdIsSetThenInjectBuildID() {
+        ProwEnvironmentContributor instance = spy(new ProwEnvironmentContributor());
+        when(instance.getEnv("PROW_JOB_ID")).thenReturn("jobid");
+        when(instance.getEnv("BUILD_ID")).thenReturn("buildid");
+
+        EnvVars envvars = new EnvVars();
+        envvars.put("BUILD_ID", "1");
+
+        instance.buildEnvironmentFor(run, envvars, listener);
+
+        assertEquals("buildid", envvars.get("BUILD_ID"));
+        assertEquals("buildid", envvars.get("BUILD_NUMBER"));
+    }
+
+    @Test
+    public void whenProwJobIdIsSetButNotBuildIdThenDontInjectBuildID() {
+        ProwEnvironmentContributor instance = spy(new ProwEnvironmentContributor());
+        when(instance.getEnv("PROW_JOB_ID")).thenReturn("jobid");
+
+        EnvVars envvars = new EnvVars();
+        envvars.put("BUILD_ID", "1");
+
+        instance.buildEnvironmentFor(run, envvars, listener);
+
+        assertEquals("1", envvars.get("BUILD_ID"));
+        assertFalse(envvars.containsKey("BUILD_NUMBER"));
+    }
+
+    @Test
+    public void whenProwJobIdIsNotSetThenDontInjectBuildID() {
+        ProwEnvironmentContributor instance = spy(new ProwEnvironmentContributor());
+        when(instance.getEnv("BUILD_ID")).thenReturn("buildid");
+
+        EnvVars envvars = new EnvVars();
+        envvars.put("BUILD_ID", "1");
+
+        instance.buildEnvironmentFor(run, envvars, listener);
+
+        assertEquals("1", envvars.get("BUILD_ID"));
+        assertFalse(envvars.containsKey("BUILD_NUMBER"));
+    }
+
+
+}


### PR DESCRIPTION
* BUILD_NUMBER is not being set by Prow
* Set run BUILD_ID and BUILD_NUMBER to the provided environment BUILD_ID in prow job
* Guard against inconsistent prow job environment
* Add testing

As a follow-up to https://github.com/jenkinsci/jx-resources-plugin/pull/17