### PR TITLE
Add a client validation button

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/jx/resources/GlobalPluginConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/jx/resources/GlobalPluginConfiguration/config.jelly
@@ -13,5 +13,6 @@
              description="${%namespace.desc}">
       <f:textbox/>
     </f:entry>
+    <f:validateButton method="validateClient" with="server,namespace" title="${%Test connection}" progress="${%Checking…}"/>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
Tested using a `~/.kube/config` connecting to a GKE cluster with https://github.com/fabric8io/kubernetes-client/pull/1348.