### PR TITLE
Fall back to setting jenkinsURL to JenkinsLocationConfiguration.url

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jx/resources/BuildSyncRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/resources/BuildSyncRunListener.java
@@ -30,6 +30,7 @@ import io.jenkins.x.client.kube.StageActivityStep;
 import io.jenkins.x.client.kube.Statuses;
 import io.jenkins.x.client.util.Strings;
 import io.jenkins.x.client.util.URLHelpers;
+import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.util.Timer;
 import org.apache.commons.httpclient.HttpStatus;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
@@ -409,6 +410,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
             } catch (Exception e) {
                 logger.log(WARNING, "Could not find Jenkins service in namespace " + namespace + ": " + e, e);
             }
+            jenkinsURL = JenkinsLocationConfiguration.get().getUrl();
         }
         return this.jenkinsURL;
     }

--- a/src/main/java/org/jenkinsci/plugins/jx/resources/BuildSyncRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/resources/BuildSyncRunListener.java
@@ -412,7 +412,10 @@ public class BuildSyncRunListener extends RunListener<Run> {
             } catch (Exception e) {
                 logger.log(WARNING, "Could not find Jenkins service in namespace " + namespace + ": " + e, e);
             }
-            jenkinsURL = JenkinsLocationConfiguration.get().getUrl();
+            JenkinsLocationConfiguration jlc = JenkinsLocationConfiguration.get();
+            if (jlc != null) { // TODO bogus null check, fixed as of Jenkins 2.119
+                jenkinsURL = jlc.getUrl();
+            }
         }
         return this.jenkinsURL;
     }


### PR DESCRIPTION
Serves as a fallback in case `jenkins-x.io/exposeUrl` etc. is not set.